### PR TITLE
Implement Process Transport

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -12,5 +12,27 @@ config :bgp, BGP.MyServer,
       asn: 64496,
       bgp_id: "172.16.1.4",
       host: "172.16.1.4"
+    ],
+    [
+      asn: 65_536,
+      bgp_id: "172.16.1.2",
+      host: "172.16.1.2",
+      transport: BGP.Server.Session.Transport.Process,
+      transport_opts: [server: BGP.MyOtherServer]
+    ]
+  ]
+
+config :bgp, BGP.MyOtherServer,
+  asn: 65_536,
+  bgp_id: "172.16.1.2",
+  networks: ["12.12.0.0/20"],
+  port: 180,
+  peers: [
+    [
+      asn: 65_536,
+      bgp_id: "172.16.1.3",
+      host: "172.16.1.3",
+      transport: BGP.Server.Session.Transport.Process,
+      transport_opts: [server: BGP.MyServer]
     ]
   ]

--- a/lib/bgp/application.ex
+++ b/lib/bgp/application.ex
@@ -7,7 +7,7 @@ defmodule BGP.Application do
   def start(_type, _args) do
     children =
       if Mix.env() == :dev do
-        [{BGP.Server, BGP.MyServer}]
+        [{BGP.Server, BGP.MyServer}, {BGP.Server, BGP.MyOtherServer}]
       else
         []
       end

--- a/lib/bgp/my_other_server.ex
+++ b/lib/bgp/my_other_server.ex
@@ -1,4 +1,4 @@
-defmodule BGP.MyServer do
+defmodule BGP.MyOtherServer do
   @moduledoc false
 
   use BGP.Server, otp_app: :bgp

--- a/lib/bgp/my_other_server.ex
+++ b/lib/bgp/my_other_server.ex
@@ -1,0 +1,5 @@
+defmodule BGP.MyServer do
+  @moduledoc false
+
+  use BGP.Server, otp_app: :bgp
+end

--- a/lib/bgp/my_server.ex
+++ b/lib/bgp/my_server.ex
@@ -1,4 +1,4 @@
-defmodule BGP.MyServer do
+defmodule BGP.MyOtherServer do
   @moduledoc false
 
   use BGP.Server, otp_app: :bgp

--- a/lib/bgp/my_server.ex
+++ b/lib/bgp/my_server.ex
@@ -1,4 +1,4 @@
-defmodule BGP.MyOtherServer do
+defmodule BGP.MyServer do
   @moduledoc false
 
   use BGP.Server, otp_app: :bgp

--- a/lib/bgp/server.ex
+++ b/lib/bgp/server.ex
@@ -88,6 +88,17 @@ defmodule BGP.Server do
                  doc: "Type of session startup.",
                  type: {:in, [:automatic, :manual]},
                  default: :automatic
+               ],
+               transport: [
+                 doc:
+                   "Server transport. Allows to use a transport different from TCP. Not normally needed.",
+                 type: :atom,
+                 default: BGP.Server.Session.Transport.TCP
+               ],
+               transport_opts: [
+                 doc: "Server transport options. Transport specific.",
+                 type: :keyword_list,
+                 default: []
                ]
 
   @server_schema asn: [
@@ -114,12 +125,6 @@ defmodule BGP.Server do
                    doc: "List of peer configurations (`t:peer_options/0`).",
                    type: {:list, {:keyword_list, @peer_schema}},
                    default: []
-                 ],
-                 transport: [
-                   doc:
-                     "Server transport. Allows to use a transport different from TCP. Not normally needed.",
-                   type: :atom,
-                   default: BGP.Server.Session.Transport.TCP
                  ]
 
   @typedoc """

--- a/lib/bgp/server.ex
+++ b/lib/bgp/server.ex
@@ -239,5 +239,5 @@ defmodule BGP.Server do
   def session_registry(server), do: Module.concat(server, "Session.Registry")
 
   @spec session_via(t(), IP.Address.t()) :: {:via, module(), term()}
-  def session_via(server, hostname), do: {:via, Registry, {session_registry(server), hostname}}
+  def session_via(server, host), do: {:via, Registry, {session_registry(server), host}}
 end

--- a/lib/bgp/server/session.ex
+++ b/lib/bgp/server/session.ex
@@ -71,7 +71,8 @@ defmodule BGP.Server.Session do
           socket: Transport.socket(),
           start: start(),
           timers: %{atom() => Timer.t()},
-          transport: Transport.t()
+          transport: Transport.t(),
+          transport_opts: keyword()
         }
 
   @type t :: :gen_statem.server_ref()
@@ -85,7 +86,8 @@ defmodule BGP.Server.Session do
     :port,
     :server,
     :start,
-    :transport
+    :transport,
+    :transport_opts
   ]
   defstruct asn: nil,
             bgp_id: nil,
@@ -104,7 +106,8 @@ defmodule BGP.Server.Session do
             socket: nil,
             start: nil,
             timers: %{},
-            transport: nil
+            transport: nil,
+            transport_opts: []
 
   @doc false
   def child_spec(opts), do: %{id: __MODULE__, start: {__MODULE__, :start_link, [opts]}}
@@ -1284,7 +1287,8 @@ defmodule BGP.Server.Session do
           %{},
           &{&1, Timer.new(get_in(peer, [&1, :seconds]), get_in(peer, [&1, :enabled?]) != false)}
         ),
-      transport: server[:transport]
+      transport: peer[:transport],
+      transport_opts: peer[:transport_opts]
     }
   end
 

--- a/lib/bgp/server/session/transport/process.ex
+++ b/lib/bgp/server/session/transport/process.ex
@@ -10,7 +10,7 @@ defmodule BGP.Server.Session.Transport.Process do
 
   @impl Transport
   def connect(%Session{} = data) do
-    with {:ok, pid} <- Server.session_for(data.server, data.host),
+    with {:ok, pid} <- Server.session_for(data.transport_opts[:server], data.host),
          :ok <- :gen_statem.call(pid, {:process_connect}) do
       {:ok, pid}
     end
@@ -18,7 +18,7 @@ defmodule BGP.Server.Session.Transport.Process do
 
   @impl Transport
   def disconnect(%Session{} = data) do
-    with {:ok, pid} <- Server.session_for(data.server, data.host),
+    with {:ok, pid} <- Server.session_for(data.transport_opts[:server], data.host),
          do: :gen_statem.call(pid, {:process_disconnect})
   end
 

--- a/lib/bgp/server/session/transport/process.ex
+++ b/lib/bgp/server/session/transport/process.ex
@@ -10,7 +10,8 @@ defmodule BGP.Server.Session.Transport.Process do
 
   @impl Transport
   def connect(%Session{} = data) do
-    with {:ok, pid} <- Server.session_for(data.transport_opts[:server], data.host),
+    with {:ok, pid} <-
+           Server.session_for(data.transport_opts[:server], data.bgp_id),
          :ok <- :gen_statem.call(pid, {:process_connect}) do
       {:ok, pid}
     end
@@ -18,13 +19,14 @@ defmodule BGP.Server.Session.Transport.Process do
 
   @impl Transport
   def disconnect(%Session{} = data) do
-    with {:ok, pid} <- Server.session_for(data.transport_opts[:server], data.host),
+    with {:ok, pid} <- Server.session_for(data.transport_opts[:server], data.bgp_id),
          do: :gen_statem.call(pid, {:process_disconnect})
   end
 
   @impl Transport
   def send(%Session{} = data, msg) do
     {_msg_data, data} = Message.encode(msg, data)
-    with :ok <- :gen_statem.call(data.socket, {:process_recv, msg}), do: {:ok, data}
+
+    with :ok <- :gen_statem.cast(data.socket, {:process_recv, msg}), do: {:ok, data}
   end
 end

--- a/lib/bgp/server/session/transport/process.ex
+++ b/lib/bgp/server/session/transport/process.ex
@@ -10,8 +10,7 @@ defmodule BGP.Server.Session.Transport.Process do
 
   @impl Transport
   def connect(%Session{} = data) do
-    with {:ok, pid} <-
-           Server.session_for(data.transport_opts[:server], data.bgp_id),
+    with {:ok, pid} <- Server.session_for(data.transport_opts[:server], data.bgp_id),
          :ok <- :gen_statem.call(pid, {:process_connect}) do
       {:ok, pid}
     end

--- a/test/bgp/message_test.exs
+++ b/test/bgp/message_test.exs
@@ -22,7 +22,8 @@ defmodule BGP.MessageTest do
         port: 179,
         start: :manual,
         server: nil,
-        transport: TCP
+        transport: TCP,
+        transport_opts: []
       }
     }
   end


### PR DESCRIPTION
Add process transport implementation.

This allows to establish BGP sessions between servers in the same Erlang VM using messaging between processes instead of TCP connections.