### PR TITLE
Fix process transport reliability issues

### DIFF
--- a/lib/bgp/server/session.ex
+++ b/lib/bgp/server/session.ex
@@ -179,7 +179,7 @@ defmodule BGP.Server.Session do
         }
 
       {:error, error} ->
-        Logger.error("Connection to peer #{data.host} failed, reason: #{error}")
+        Logger.error("Connection to peer #{data.host} failed, reason: #{inspect(error)}")
         {:keep_state, %{data | socket: nil, buffer: <<>>}}
     end
   end
@@ -434,6 +434,8 @@ defmodule BGP.Server.Session do
       ]
     }
   end
+
+  def handle_event(_event_type, _event, :idle, _data), do: :keep_state_and_data
 
   def handle_event(_event_type, {:start, _type, _mode}, :connect, _data), do: :keep_state_and_data
 

--- a/lib/bgp/server/session/transport/process.ex
+++ b/lib/bgp/server/session/transport/process.ex
@@ -14,12 +14,18 @@ defmodule BGP.Server.Session.Transport.Process do
          :ok <- :gen_statem.call(pid, {:process_connect}) do
       {:ok, pid}
     end
+  catch
+    type, error ->
+      {:error, {type, error}}
   end
 
   @impl Transport
   def disconnect(%Session{} = data) do
     with {:ok, pid} <- Server.session_for(data.transport_opts[:server], data.bgp_id),
          do: :gen_statem.call(pid, {:process_disconnect})
+  catch
+    type, error ->
+      {:error, {type, error}}
   end
 
   @impl Transport


### PR DESCRIPTION
There are two issues here:

- Process lookups via registry might raise an `ArgumentError` exception when the registry is not yet started for the specified peer when using process transport. This is easily fixed by catching the exception and returning an error.
- Sessions in  `idle` state should ignore every event not explicitly allowed as per RFC. Otherwise events cause crashes because they are not handled.

These make simulating a topology much more reliable.