### PR TITLE
Improve process transport

### DIFF
--- a/lib/bgp/server.ex
+++ b/lib/bgp/server.ex
@@ -165,23 +165,18 @@ defmodule BGP.Server do
 
   @impl Supervisor
   def init(args) do
-    ret =
-      Supervisor.init(
-        [
-          {Registry, keys: :unique, name: session_registry(args[:server])},
-          {BGP.Server.RDE, server: args[:server]},
-          {BGP.Server.Session.Supervisor, args[:server]},
-          {
-            ThousandIsland,
-            port: args[:port], handler_module: BGP.Server.Session, handler_options: args
-          }
-        ],
-        strategy: :one_for_all
-      )
-
-    :telemetry.execute([:bgp, :server, :start], %{}, %{server: args[:server]})
-
-    ret
+    Supervisor.init(
+      [
+        {Registry, keys: :unique, name: session_registry(args[:server])},
+        {BGP.Server.RDE, server: args[:server]},
+        {BGP.Server.Session.Supervisor, args[:server]},
+        {
+          ThousandIsland,
+          port: args[:port], handler_module: BGP.Server.Session, handler_options: args
+        }
+      ],
+      strategy: :one_for_all
+    )
   end
 
   @spec get_config(t()) :: keyword()
@@ -242,6 +237,9 @@ defmodule BGP.Server do
 
   @spec session_registry(t()) :: module()
   def session_registry(server), do: Module.concat(server, "Session.Registry")
+
+  @spec session_supervisor(t()) :: module()
+  def session_supervisor(server), do: Module.concat(server, "Session.Supervisor")
 
   @spec session_via(t(), IP.Address.t()) :: {:via, module(), term()}
   def session_via(server, host), do: {:via, Registry, {session_registry(server), host}}

--- a/lib/bgp/server/session.ex
+++ b/lib/bgp/server/session.ex
@@ -1280,7 +1280,7 @@ defmodule BGP.Server.Session do
     end
   end
 
-  def handle_event(_type, _event, :establised, data) do
+  def handle_event(_type, _event, :established, data) do
     {
       :next_state,
       :idle,

--- a/lib/bgp/server/session/supervisor.ex
+++ b/lib/bgp/server/session/supervisor.ex
@@ -4,22 +4,26 @@ defmodule BGP.Server.Session.Supervisor do
   use Supervisor
 
   alias BGP.Server
+  alias BGP.Server.Session
 
   @doc false
   def child_spec(server),
     do: %{id: server, type: :supervisor, start: {__MODULE__, :start_link, [server]}}
 
   @spec start_link(Server.t()) :: Supervisor.on_start()
-  def start_link(server) do
-    Supervisor.start_link(__MODULE__, server, name: Module.concat(server, "Session.Supervisor"))
-  end
+  def start_link(server),
+    do: Supervisor.start_link(__MODULE__, server, name: Server.session_supervisor(server))
+
+  @spec start_child(Supervisor.supervisor(), Server.peer_options()) :: Supervisor.on_start_child()
+  def start_child(supervisor, peer_options),
+    do: Supervisor.start_child(supervisor, Session.child_spec({peer_options, []}))
 
   @impl Supervisor
   def init(server) do
     children =
       Server.get_config(server)
       |> Keyword.fetch!(:peers)
-      |> Enum.map(&{BGP.Server.Session, &1})
+      |> Enum.map(&{Session, &1})
 
     Supervisor.init(children, strategy: :one_for_one)
   end

--- a/lib/bgp/server/session/transport/process.ex
+++ b/lib/bgp/server/session/transport/process.ex
@@ -36,7 +36,9 @@ defmodule BGP.Server.Session.Transport.Process do
   @impl Transport
   def send(%Session{} = data, msg) do
     {_msg_data, data} = Message.encode(msg, data)
-
     with :ok <- :gen_statem.cast(data.socket, {:process_recv, msg}), do: {:ok, data}
+  catch
+    type, error ->
+      {:error, {type, error}}
   end
 end

--- a/lib/bgp/server/session/transport/tcp.ex
+++ b/lib/bgp/server/session/transport/tcp.ex
@@ -29,5 +29,8 @@ defmodule BGP.Server.Session.Transport.TCP do
   def send(%Session{} = data, msg) do
     {msg_data, data} = Message.encode(msg, data)
     with :ok <- :gen_tcp.send(data.socket, msg_data), do: {:ok, data}
+  catch
+    type, error ->
+      {:error, {type, error}}
   end
 end


### PR DESCRIPTION
This improves the process transport by making it mirror more closely the TCP transport behaviour.

Each time a session using process transport wants to establish a peering session with another server, we spawn a new session process using the remote server session supervisor and then connect to that process.

This makes sure we are not using the existing session on the remote end, and that we don't bypass collision detection logic, so that, eventually, the new session is either registered in the session registry as the active session for that peer, or shut down in case of collisions.